### PR TITLE
Open up backend server to hosts other than localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,5 @@
     "eslint-plugin-react": "^7.12.4",
     "prettier": "1.16.1"
   },
-  "proxy": "http://localhost:8080"
+  "proxy": "http://0.0.0.0:8080"
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -51,7 +51,7 @@ func (s *Server) Start() {
 	go websocketWorker.Run()
 
 	log.Print("Server started at http://localhost:" + s.Port)
-	err := http.ListenAndServe(":"+s.Port, router)
+	err := http.ListenAndServe("0.0.0.0:"+s.Port, router)
 
 	if err != nil {
 		log.Fatal("Failed to start server: ", err)


### PR DESCRIPTION
While the Yarn development server listens on localhost and the
primary system interface, the Facet backend server does not.
Open up the backend server to listen on all interfaces in a
manner similar to the Yarn development server, to aid in
remote development.