### PR TITLE
Update import paths to openshift-metalkube.

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,8 +16,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/metalkube/facet/cmd/host"
-	"github.com/metalkube/facet/cmd/server"
+	"github.com/openshift-metalkube/facet/cmd/host"
+	"github.com/openshift-metalkube/facet/cmd/server"
 	"github.com/spf13/cobra"
 	"os"
 )


### PR DESCRIPTION
After repo migration build.sh fails with error:
```bash
  + /root/go/bin/statik -f -src build
  + go build main.go
  # command-line-arguments
  ./main.go:31:17: cannot use server.Cmd (type *"github.com/metalkube/facet/vendor/github.com/spf13/cobra".Command) as type *"github.com/openshift-metalkube/facet/vendor/github.com/spf13/cobra".Command in
   argument to root.AddCommand
  ./main.go:32:17: cannot use host.Cmd (type *"github.com/metalkube/facet/vendor/github.com/spf13/cobra".Command) as type *"github.com/openshift-metalkube/facet/vendor/github.com/spf13/cobra".Command in a
  rgument to root.AddCommand
```